### PR TITLE
Fixed infinite likes issue MVP ✨

### DIFF
--- a/src/components/Gallery.js
+++ b/src/components/Gallery.js
@@ -1,39 +1,12 @@
-import { FaRegTrashAlt } from 'react-icons/fa';
 import firebase from '../firebase';
-import { getDatabase, ref, onValue, remove, update } from 'firebase/database';
+import { getDatabase, ref, onValue } from 'firebase/database';
 import { useEffect, useState } from 'react';
-import { useUserAuth } from '../context/UserAuthContext.js';
-import DeleteConfirmation from './DeleteConfirmation.js';
+import GalleryCard from './GalleryCard';
 
 function Gallery({ closeGallery, showGallery }) {
   //useState for gallery of user's backronym
   const [gallery, setGallery] = useState([]);
   const [backronymFilter, setBackronymFilter] = useState('recent');
-  const [deleteWarning, setDeleteWarning] = useState(false);
-  const [deleteID, setDeleteID] = useState('');
-  let { user } = useUserAuth();
-
-  // delete entry
-  function handleDelete(e, resultKey) {
-    e.preventDefault();
-    const database = getDatabase(firebase);
-    const dbRef = ref(database, `/${resultKey}`);
-    remove(dbRef);
-
-    //reset delete ID state
-    setDeleteID('');
-  }
-
-  //updating like count
-  function handleLike(resultKey, resultLikes) {
-    const updatedLikes = {
-      likes: resultLikes + 1,
-    };
-
-    const database = getDatabase(firebase);
-    const childRef = ref(database, `/${resultKey}`);
-    update(childRef, updatedLikes);
-  }
 
   //connect to firebase when Gallery component mounts
   useEffect(() => {
@@ -111,66 +84,7 @@ function Gallery({ closeGallery, showGallery }) {
             {
               // map over the gallery state (from firebase). Results is each submission
               gallery.map((result) => {
-                return (
-                  <li className="galleryCard" key={result.key}>
-                    <h3>{result.userInput}</h3>
-                    {/* mapping over each user's submission results array item (each word in array is the initial) */}
-                    {result.results.map((initialWord, index) => {
-                      return <p key={`${result.key}-${index}`}>{initialWord}</p>;
-                    })}
-
-                    <div className="userGalleryControls">
-                      {user === null ? (
-                        ''
-                      ) : user.email === result.email ? (
-                        <button
-                          className="deleteBtn"
-                          onClick={(e) => {
-                            setDeleteWarning(true);
-                            setDeleteID(result.key);
-                          }}
-                        >
-                          <span className="sr-only">Delete</span>
-                          <FaRegTrashAlt />
-                        </button>
-                      ) : user.email === null && result.email === 'anonymous' ? (
-                        <button
-                          className="deleteBtn"
-                          onClick={(e) => {
-                            setDeleteWarning(true);
-                            setDeleteID(result.key);
-                          }}
-                        >
-                          <span className="sr-only">Delete</span>
-                          <FaRegTrashAlt />
-                        </button>
-                      ) : (
-                        ''
-                      )}
-
-                      {deleteWarning ? (
-                        <DeleteConfirmation
-                          setDeleteWarning={setDeleteWarning}
-                          handleDelete={handleDelete}
-                          deleteID={deleteID}
-                        />
-                      ) : null}
-
-                      {user ? (
-                        <button
-                          className="likeBtn"
-                          onClick={() => {
-                            handleLike(result.key, result.likes);
-                          }}
-                        >
-                          <span className="sr-only">Like</span>
-                        </button>
-                      ) : null}
-
-                      <p className="likeCount">{result.likes}</p>
-                    </div>
-                  </li>
-                );
+                return <GalleryCard result={result} key={result.key} />;
               })
             }
           </ul>

--- a/src/components/GalleryCard.js
+++ b/src/components/GalleryCard.js
@@ -1,0 +1,95 @@
+import { FaRegTrashAlt } from 'react-icons/fa';
+import DeleteConfirmation from './DeleteConfirmation.js';
+import { getDatabase, ref, remove, update } from 'firebase/database';
+import { useState } from 'react';
+import firebase from '../firebase.js';
+import { useUserAuth } from '../context/UserAuthContext.js';
+
+function GalleryCard({ result }) {
+  const [deleteWarning, setDeleteWarning] = useState(false);
+  const [deleteID, setDeleteID] = useState('');
+  // // track whether user has already liked a backronym
+  // const [likedStatus, setLikedStatus] = useState('');
+
+  let { user } = useUserAuth();
+
+  // delete entry
+  function handleDelete(e, resultKey) {
+    e.preventDefault();
+    const database = getDatabase(firebase);
+    const dbRef = ref(database, `/${resultKey}`);
+    remove(dbRef);
+
+    //reset delete ID state
+    setDeleteID('');
+  }
+
+  //updating like count
+  function handleLike(resultKey, resultLikes) {
+    const updatedLikes = {
+      likes: resultLikes + 1,
+    };
+
+    const database = getDatabase(firebase);
+    const childRef = ref(database, `/${resultKey}`);
+    update(childRef, updatedLikes);
+  }
+  return (
+    <li className="galleryCard" key={result.key}>
+      <h3>{result.userInput}</h3>
+      {/* mapping over each user's submission results array item (each word in array is the initial) */}
+      {result.results.map((initialWord, index) => {
+        return <p key={`${result.key}-${index}`}>{initialWord}</p>;
+      })}
+
+      <div className="userGalleryControls">
+        {user === null ? (
+          ''
+        ) : user.email === result.email ? (
+          <button
+            className="deleteBtn"
+            onClick={(e) => {
+              setDeleteWarning(true);
+              setDeleteID(result.key);
+            }}
+          >
+            <span className="sr-only">Delete</span>
+            <FaRegTrashAlt />
+          </button>
+        ) : user.email === null && result.email === 'anonymous' ? (
+          <button
+            className="deleteBtn"
+            onClick={(e) => {
+              setDeleteWarning(true);
+              setDeleteID(result.key);
+            }}
+          >
+            <span className="sr-only">Delete</span>
+            <FaRegTrashAlt />
+          </button>
+        ) : (
+          ''
+        )}
+
+        {deleteWarning ? (
+          <DeleteConfirmation setDeleteWarning={setDeleteWarning} handleDelete={handleDelete} deleteID={deleteID} />
+        ) : null}
+
+        {user ? (
+          <button
+            className="likeBtn"
+            onClick={() => {
+              handleLike(result.key, result.likes);
+            }}
+          >
+            <span className="sr-only">Like</span>
+          </button>
+        ) : null}
+
+        <p className="likeCount">{result.likes}</p>
+      </div>
+    </li>
+  );
+}
+
+export default GalleryCard;

--- a/src/components/GalleryCard.js
+++ b/src/components/GalleryCard.js
@@ -1,15 +1,17 @@
 import { FaRegTrashAlt } from 'react-icons/fa';
 import DeleteConfirmation from './DeleteConfirmation.js';
 import { getDatabase, ref, remove, update } from 'firebase/database';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import firebase from '../firebase.js';
 import { useUserAuth } from '../context/UserAuthContext.js';
+import ErrorModal from './ErrorModal.js';
 
 function GalleryCard({ result }) {
   const [deleteWarning, setDeleteWarning] = useState(false);
   const [deleteID, setDeleteID] = useState('');
   // // track whether user has already liked a backronym
-  // const [likedStatus, setLikedStatus] = useState('');
+  const [likedStatus, setLikedStatus] = useState('');
+  const [error, setError] = useState('');
 
   let { user } = useUserAuth();
 
@@ -26,16 +28,30 @@ function GalleryCard({ result }) {
 
   //updating like count
   function handleLike(resultKey, resultLikes) {
-    const updatedLikes = {
-      likes: resultLikes + 1,
-    };
+    // check if the user has already liked this specific backronym
+    const liked = localStorage.getItem(`${result.key}`);
+    setLikedStatus(liked);
 
-    const database = getDatabase(firebase);
-    const childRef = ref(database, `/${resultKey}`);
-    update(childRef, updatedLikes);
+    if (likedStatus !== 'liked') {
+      const updatedLikes = {
+        likes: resultLikes + 1,
+      };
+
+      const database = getDatabase(firebase);
+      const childRef = ref(database, `/${resultKey}`);
+      update(childRef, updatedLikes);
+
+      // // set liked status to local storage
+      localStorage.setItem(`${result.key}`, 'liked');
+    } else {
+      setError("You've already liked this!");
+    }
   }
+
   return (
     <li className="galleryCard" key={result.key}>
+      {error ? <ErrorModal errorMsg={error} setError={setError} /> : null}
+
       <h3>{result.userInput}</h3>
       {/* mapping over each user's submission results array item (each word in array is the initial) */}
       {result.results.map((initialWord, index) => {

--- a/src/components/UserProfile.js
+++ b/src/components/UserProfile.js
@@ -1,184 +1,128 @@
-import { FaRegTrashAlt } from 'react-icons/fa';
 import firebase from '../firebase';
-import { getDatabase, ref, onValue, remove, update } from 'firebase/database';
+import { getDatabase, ref, onValue, remove } from 'firebase/database';
 import { Link, useParams } from 'react-router-dom';
 import { useUserAuth } from '../context/UserAuthContext';
 import { useEffect, useState } from 'react';
+import ErrorModal from './ErrorModal';
 
 import ErrorPage from '../pages/ErrorPage';
-import DeleteConfirmation from './DeleteConfirmation';
+import GalleryCard from './GalleryCard';
 
 function UserProfile() {
-    const [gallery, setGallery] = useState([]);
-    const { user, deleteProfile } = useUserAuth();
-    const [error, setError] = useState('');
-    const [backronymKeys, setBackronymKeys] = useState([]);
-    const [deleteWarning, setDeleteWarning] = useState(false);
-    const [deleteID, setDeleteID] = useState('');
-    const [deleteAccountAttempt, setDeleteAccountAttempt] = useState(false);
-    const { uid } = useParams();
+  const [gallery, setGallery] = useState([]);
+  const { user, deleteProfile } = useUserAuth();
+  const [error, setError] = useState('');
+  const [backronymKeys, setBackronymKeys] = useState([]);
+  const [deleteAccountAttempt, setDeleteAccountAttempt] = useState(false);
+  const { uid } = useParams();
 
-    //updating like count
-    function handleLike(resultKey, resultLikes) {
-        const updatedLikes = {
-        likes: resultLikes + 1,
-        };
-
-        const database = getDatabase(firebase);
-        const childRef = ref(database, `/${resultKey}`);
-        update(childRef, updatedLikes);
-    }
-
-    // delete entry
-    function handleDelete(e, resultKey) {
-        e.preventDefault();
-        const database = getDatabase(firebase);
-        const dbRef = ref(database, `/${resultKey}`);
+  // delete user's of backronyms
+  function handleDeleteBackronyms(backronymKeyList) {
+    if (backronymKeyList.length > 0) {
+      const database = getDatabase(firebase);
+      for (let key of backronymKeyList) {
+        const dbRef = ref(database, `/${key}`);
         remove(dbRef);
-
-        setDeleteID('');
+      }
     }
+  }
 
-    // delete user's of backronyms
-    function handleDeleteBackronyms(backronymKeyList) {
-        if (backronymKeyList.length > 0) {
-            const database = getDatabase(firebase);
-            for (let key of backronymKeyList) {
-                const dbRef = ref(database, `/${key}`);
-                remove(dbRef);
-            }
+  // delete account
+  const handleUserAccountDeletion = async (e) => {
+    handleDeleteBackronyms(backronymKeys);
+
+    setError('');
+    try {
+      await deleteProfile();
+    } catch (err) {
+      setError(err.message);
+    }
+  };
+
+  useEffect(() => {
+    // database details
+    const database = getDatabase(firebase);
+    const dbRef = ref(database);
+
+    onValue(dbRef, (response) => {
+      const newState = [];
+      const data = response.val();
+      for (let key in data) {
+        newState.push({
+          key: key,
+          timestamp: data[key].timestamp,
+          email: data[key].email,
+          userInput: data[key].userInput,
+          results: data[key].results,
+          likes: data[key].likes,
+        });
+      }
+      setGallery(newState);
+    });
+  }, []);
+
+  useEffect(() => {
+    const tempKeyState = [];
+    gallery.forEach((result) => {
+      if (result.email === user.email || (result.email === 'anonymous' && user.email === null)) {
+        tempKeyState.push(result.key);
+      }
+    });
+    setBackronymKeys(tempKeyState);
+  }, [gallery]);
+
+  return (
+    <section className="userProfile">
+      {error ? <ErrorModal errorMsg={error} setError={setError} /> : null}
+      <div className={`accountDeleteBanner ${deleteAccountAttempt ? `addHeight` : ``}`}>
+        {
+          <div className="deleteMessageContainer wrapper">
+            <p>
+              Deleting your account is permanent and will erase ALL your backronyms. Are you sure you would like to
+              proceed?
+            </p>
+            <div className="deleteButtonContainer">
+              <Link to="/login">
+                <button onClick={(e) => handleUserAccountDeletion(e)}>Confirm</button>
+              </Link>
+              <button onClick={() => setDeleteAccountAttempt(false)}>Cancel</button>
+            </div>
+          </div>
         }
-    }
+      </div>
+      <div className="wrapper">
+        <h2>Your Profile</h2>
+        {uid === user.uid && backronymKeys.length === 0 ? (
+          <div className="emptyProfileMessage">
+            <h3>Oops! Looks like you don't have any backronyms created. Go back to the main page to get started!</h3>
+          </div>
+        ) : null}
 
-    // delete account
-    const handleUserAccountDeletion = async (e) => {
-        
-        handleDeleteBackronyms(backronymKeys);
-
-        setError('');
-        try {
-            await deleteProfile();
-        } catch (err) {
-            setError(err.message);
-        }
-    }
-
-    useEffect(() => {
-        // database details
-        const database = getDatabase(firebase);
-        const dbRef = ref(database);
-            
-        onValue(dbRef, (response) => {
-            const newState = [];
-            const data = response.val();
-            for(let key in data) {
-                newState.push({
-                    key: key,
-                    timestamp: data[key].timestamp,
-                    email: data[key].email,
-                    userInput: data[key].userInput,
-                    results: data[key].results,
-                    likes: data[key].likes,
-                })
-            }
-            setGallery(newState);
-        })
-    }, []);
-
-    useEffect(() => {
-        const tempKeyState = [];
-            gallery.forEach((result) => {
-                if (result.email === user.email || (result.email === 'anonymous' && user.email === null)) {
-                    tempKeyState.push(result.key);
-                }
+        <ul className="resultsDisplay">
+          {uid === user.uid ? (
+            gallery.map((result) => {
+              return result.email === user.email || (result.email === 'anonymous' && user.email === null) ? (
+                <GalleryCard result={result} key={result.key} />
+              ) : (
+                ''
+              );
             })
-        setBackronymKeys(tempKeyState);
-    }, [gallery]);
+          ) : (
+            <ErrorPage />
+          )}
+        </ul>
 
-    return(
-        <section className="userProfile">
-            <div className={`accountDeleteBanner ${deleteAccountAttempt ? `addHeight` : ``}`}>
-                {
-                    <div className='deleteMessageContainer wrapper'>
-                        <p>Deleting your account is permanent and will erase ALL your backronyms. Are you sure you would like to proceed?</p>
-                        <div className='deleteButtonContainer'>
-                        <Link to="/login">
-                            <button onClick={(e) => handleUserAccountDeletion(e)}>Confirm</button>
-                        </Link>
-                        <button onClick={() => setDeleteAccountAttempt(false)}>Cancel</button>
-                        </div>
-                        
-                    </div>
-                }
-            </div>
-            <div className="wrapper">
-                <h2>Your Profile</h2>
-                {
-                    uid === user.uid && backronymKeys.length === 0 ?
-                    <div className="emptyProfileMessage">
-                        <h3>Oops! Looks like you don't have any backronyms created. Go back to the main page to get started!</h3>
-                    </div>
-                    : null
-                }
-
-                <ul className="resultsDisplay">
-                    {
-                        uid === user.uid ?
-                        gallery.map((result) => {
-                            return(
-                                (result.email === user.email || (result.email === 'anonymous' && user.email === null)) ?
-                                <li className="galleryCard" key={result.key}>
-                                    <div className="userGalleryControls">
-
-                                        <button className="deleteBtn" onClick={(e) => {
-                                            setDeleteWarning(true);
-                                            setDeleteID(result.key);
-                                            }}>
-
-                                            <span className="sr-only">Delete</span>
-                                            <FaRegTrashAlt />
-
-                                        </button>
-
-                                        {deleteWarning ? (
-                                            <DeleteConfirmation
-                                            setDeleteWarning={setDeleteWarning}
-                                            handleDelete={handleDelete}
-                                            deleteID={deleteID}
-                                            />
-                                        ) : null}
-
-                                        <button
-                                        className="likeBtn"
-                                        onClick={() => {
-                                            handleLike(result.key, result.likes);
-                                        }}>
-                                            <span className="sr-only">Like</span>
-                                        </button>
-                                        <p className="likeCount">{result.likes}</p>
-                                    </div>
-                                    <h3>{result.userInput}</h3>
-                                    {
-                                        result.results.map((initialWord, index) => {
-                                            return <p key={`${result.key}-${index}`}>{initialWord}</p>;
-                                        })
-                                    }
-                                </li> : ""
-                            )
-                        }) : <ErrorPage />
-                    }
-                </ul>
-
-                <div className='profileButtons'>
-                    <Link to="/">
-                        <button className='backButton'>Back</button>
-                    </Link>
-                    <button className='deleteProfileButton' onClick={() => setDeleteAccountAttempt(true)}
-                    >Delete Account</button>
-                </div>
-            </div>
-        </section>
-    )
+        <div className="profileButtons">
+          <Link to="/">
+            <button className="backButton">Back</button>
+          </Link>
+          <button className="deleteProfileButton" onClick={() => setDeleteAccountAttempt(true)}>
+            Delete Account
+          </button>
+        </div>
+      </div>
+    </section>
+  );
 }
 
 export default UserProfile;


### PR DESCRIPTION
Done:
- moved gallery card into its own component to allow better individual card key manipulation (setup for this likes fix)
- limit user likes to 1 per card using local storage
- update this likes fix on user profile page and cleaned up all functions that are only related to gallery card (avoid repetition of functions in gallery and user profile since they both use the gallery card component directly which has all the functions it needs to delete/ update likes etc.)

Limitations:
- I don't think it differentiates different anonymous sessions (e.g. if someone who logs in as anon likes, then another anon might not be able to like that same word) - TO BE TESTED MORE I'M NOT SURE ON THIS but it's 3am so going to sleep 😇

To do:
- there's a bug when if the user clicks the like fast enough, they can get two likes in before the alert blocks them, this is because local storage is not an async function and takes like 2 seconds to update local storage status. to fix this, need to await set local storage function to stop user from getting two likes in (this is still better than infinite anyways)
- bug where if you like your own post in gallery and then go on your profile, you can like it one more time again.. fix could be to add a condition to not allow user to like their own posts..
- to include unlike functionality, but should be straight forward with current setup