### PR TITLE
Chow branch

### DIFF
--- a/src/components/AboutModal.js
+++ b/src/components/AboutModal.js
@@ -10,7 +10,7 @@ const AboutModal = props => {
     if (props.show) {
       document.body.style.overflow = 'hidden';
     } else {
-      document.body.style.overflow = 'unset';
+      document.body.style.overflow = 'auto';
     }
   }, [props.show])
 

--- a/src/components/NavBar.js
+++ b/src/components/NavBar.js
@@ -45,19 +45,19 @@ function NavBar() {
 
         <div className="navLinksContainer">
           <div className={`navLinks ${nav ? 'showNav' : ''}`}>
-          <ul className="linkContainer">
+          <ul className="linkContainer" onClick={toggleNav}>
             {/* for when user is on user page, can go back to home */}
             <li>
-              <Link to={`/`} onClick={toggleNav}>Home</Link>
+              <Link to={`/`}>Home</Link>
             </li>
 
             <li>
-              <Link to={`/ngramviewer`} onClick={toggleNav}>Ngram Viewer</Link>
+              <Link to={`/ngramviewer`}>Ngram Viewer</Link>
             </li>
 
             {user ? (
               <li>
-                <Link to={`/profile/${user.uid}`} onClick={toggleNav}>Profile</Link>
+                <Link to={`/profile/${user.uid}`}>Profile</Link>
               </li>
             )
               : null

--- a/src/components/NavBar.js
+++ b/src/components/NavBar.js
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useUserAuth } from '../context/UserAuthContext';
 import ErrorModal from './ErrorModal';
 import AboutModal from './AboutModal';
@@ -10,14 +10,14 @@ function NavBar() {
   const [error, setError] = useState('');
   const [nav, setNav] = useState(false);
 
-  //hide overflowing elements when slide out nav is shown on page
-  // useEffect(() => {
-  //   if (nav === true) {
-  //     document.body.style.overflow = 'hidden';
-  //   } else {
-  //     document.body.style.overflow = 'auto';
-  //   }
-  // }, [nav])
+  //Hide overflowing elements when slide out nav is shown on page. This is to prevent users to be able to scroll the base html while the navbar is out
+  useEffect(() => {
+    if (nav) {
+      document.body.style.overflow = 'hidden';
+    } else {
+      document.body.style.overflow = 'auto';
+    }
+  }, [nav])
 
   const { user, logOut } = useUserAuth();
 
@@ -44,7 +44,8 @@ function NavBar() {
       ) : null}
 
       <nav className="mainNav">
-        <div className="hamburgerMenu"
+        <span className="sr-only">Open website menu</span>
+        <div className="hamburgerMenu" tabindex="0"
           onClick={toggleNav}
         >
           <span className={`top ${nav ? 'topClosed' : ''}`}></span>

--- a/src/components/SignUp.js
+++ b/src/components/SignUp.js
@@ -39,7 +39,7 @@ function SignUp({ toggleSignUpModal }) {
   };
 
   return (
-    <div className="signUpContainer signUpModal" onClick={(e) => toggleSignUpModal(e)}>
+    <div className="signUpContainer signUpModal">
       <div className="signUpContent">
         <h2>Sign Up</h2>
         {error ? <ErrorModal errorMsg={error} setError={setError} /> : null}

--- a/src/components/UserProfile.js
+++ b/src/components/UserProfile.js
@@ -137,9 +137,9 @@ function UserProfile() {
 
             {uid === user.uid ? (
               <div className="profileButtons">
-                <Link to="/">
+                {/* <Link to="/">
                   <button className="backButton">Back</button>
-                </Link>
+                </Link> */}
                 <button className="deleteProfileButton" onClick={() => setDeleteAccountAttempt(true)}>
                   Delete Account
                 </button>

--- a/src/components/UserProfile.js
+++ b/src/components/UserProfile.js
@@ -3,12 +3,13 @@ import { getDatabase, ref, onValue, remove } from 'firebase/database';
 import { Link, useParams } from 'react-router-dom';
 import { useUserAuth } from '../context/UserAuthContext';
 import { useEffect, useState } from 'react';
-import ErrorModal from './ErrorModal';
 
+import ErrorModal from './ErrorModal';
 import ErrorPage from '../pages/ErrorPage';
 import GalleryCard from './GalleryCard';
-
 import Loading from './Loading';
+import NavBar from './NavBar';
+
 import timeout from '../utilities/timeout';
 
 function UserProfile() {
@@ -107,6 +108,8 @@ function UserProfile() {
               </div>
             </div>
           </div>
+
+          <NavBar />
 
           <div className="wrapper">
             <h2>Your Profile</h2>

--- a/src/components/UserProfile.js
+++ b/src/components/UserProfile.js
@@ -87,12 +87,12 @@ function UserProfile() {
     return(
         <div>
 
-            { loading ?
-                <section className="loadingSection userLoading">
-                    <Loading />
-                </section>
+        { loading ?
+            <section className="loadingSection userLoading">
+              <Loading />
+            </section>
 
-                :
+            :
 
         <section className="userProfile">
 
@@ -132,18 +132,18 @@ function UserProfile() {
           )}
         </ul>
 
-                        {uid === user.uid ?
-                <div className='profileButtons'>
-                    <Link to="/">
-                        <button className='backButton'>Back</button>
-                    </Link>
-                    <button className='deleteProfileButton' onClick={() => setDeleteAccountAttempt(true)}
-                    >Delete Account</button>
-                            </div> : null    
-                        }
-            </div>
-        </section>
-            }
+          {uid === user.uid ?
+            <div className='profileButtons'>
+              <Link to="/">
+                <button className='backButton'>Back</button>
+                </Link>
+                <button className='deleteProfileButton' onClick={() => setDeleteAccountAttempt(true)}
+                >Delete Account</button>
+            </div> : null    
+          }
+          </div>
+          </section>
+        }
         </div>
     )
 }

--- a/src/partials/_generalStyles.scss
+++ b/src/partials/_generalStyles.scss
@@ -2,7 +2,6 @@
 html {
   background-color: $black;
   color: $white;
-  // overflow: hidden;
 }
 
 body {

--- a/src/partials/_nav.scss
+++ b/src/partials/_nav.scss
@@ -188,19 +188,22 @@
 
 // hamburger menu (slightly adapted from chow's portfolio)
 .hamburgerMenu {
+  flex-shrink: 0;
+  display: block;
   position: relative;
-  width: 45px;
+  width: 40px;
   height: 35px;
   cursor: pointer;
   z-index: 1000;
 }
+
 
 .top,
 .mid,
 .bottom {
   display: block;
   width: 100%;
-  height: 5px;
+  height: 4px;
   border-radius: 5px;
   background-color: $white;
   position: absolute;
@@ -209,12 +212,12 @@
 .top {
   top: 0;
   transform-origin: left top;
-  transform: rotateZ(0deg);
+  transform: rotate(0deg);
   transition: transform 0.5s ease-in-out, transform 0.5s ease-in-out, background-color 0.5s ease-in-out;
 }
 
 .mid {
-  top: 48%;
+  top: 50%;
   transform: translateY(-50%);
   transition: opacity 0.5s ease-in-out;
 }
@@ -222,12 +225,12 @@
 .bottom {
   bottom: 0;
   transform-origin: left bottom;
-  transform: rotateZ(0deg);
+  transform: rotate(0deg);
   transition: transform 0.5s ease-in-out, transform 0.5s ease-in-out, background-color 0.5s ease-in-out;
 }
 
 .topClosed {
-  transform: rotateZ(45deg);
+  transform: rotate(45deg);
   width: 111%;
   background-color: $black;
 }
@@ -237,7 +240,7 @@
 }
 
 .bottomClosed {
-  transform: rotateZ(-45deg);
+  transform: rotate(-45deg);
   width: 111%;
   background-color: $black;
 }


### PR DESCRIPTION
hotfix for my disastrous navbar
- added `overflow:hidden` to main screen (the header and search) to prevent the horizontal overflowing situation when gallery is clicked 
- added additional logic to set `body` to `overflow:hidden` whenever the actual slide out menu is shown on screen (this is to prevent users from scrolling the body text while on the nav screen)
- hamburger menu should not be skinny in smaller screens anymore
- included navbar in userprofile and removed the back button (commented it out for now)
